### PR TITLE
Trying PATH_INFO rather REQUEST_URI

### DIFF
--- a/system/Kernel.php
+++ b/system/Kernel.php
@@ -79,9 +79,9 @@ class Kernel
 
 	public function getUriSegment($int=0)
 	{
-		if(isset(explode('/', trim($_SERVER['REQUEST_URI'], '/'))[$int]))
+		if(isset(explode('/', trim($_SERVER['PATH_INFO'], '/'))[$int]))
 		{
-			return explode('/', trim($_SERVER['REQUEST_URI'], '/'))[$int];
+			return explode('/', trim($_SERVER['PATH_INFO'], '/'))[$int];
 		}
 		else return null;
 	}


### PR DESCRIPTION
Trying PATH_INFO to be requested because I tested it in my app it is working means it will be helpfull if it is located in any directory rather than root.